### PR TITLE
Bugfix - infinite request loop due to resetting pipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-prod": "ng build ngx-remote-configuration --configuration production && npm run copy-files",
     "copy-files": "node scripts/post-build-copy.js",
     "pack": "npm pack ./dist/ngx-remote-configuration",
-    "watch": "ng build --watch --configuration development",
+    "watch": "ng build ngx-remote-configuration --watch --configuration development",
     "test": "ng test ngx-remote-configuration --code-coverage",
     "test-ci": "ng test ngx-remote-configuration --watch=false --browsers=ChromeHeadlessNoSandbox --code-coverage",
     "lint": "ng lint ngx-remote-configuration",


### PR DESCRIPTION
from-config pipe is impure but created new observable each time it was invoked, so when there is error while loading config, this pipe caused infinite request loop.